### PR TITLE
fix(ci): handle added and deleted routes

### DIFF
--- a/.github/workflows/check-for-api-changes.yml
+++ b/.github/workflows/check-for-api-changes.yml
@@ -125,12 +125,18 @@ jobs:
             version:breaking
           commit-message: "feat: add initial ${{ matrix.source.name }} API specification"
 
+      - name: Stage changes
+        if: steps.detect-first-run.outputs.first_run != 'true'
+        run: |
+          # Stage all changes including new files
+          git add cache/${{ matrix.source.name }}/
+
       - name: Detect changes
         if: steps.detect-first-run.outputs.first_run != 'true'
         id: detect-changes
         run: |
-          # Compare with previous version using git
-          if ! git diff --quiet HEAD cache/${{ matrix.source.name }}/routes/**; then
+          # Compare with previous version using git (including staged changes)
+          if ! git diff --quiet --cached HEAD cache/${{ matrix.source.name }}/routes/**; then
             echo "changes_detected=true" >> $GITHUB_OUTPUT
             echo "Changes detected in ${{ matrix.source.name }} API specification"
           else
@@ -138,15 +144,12 @@ jobs:
             echo "No changes detected"
           fi
 
-      - name: Diff debug
-        if: steps.detect-changes.outputs.changes_detected == 'true'
-        run: git diff HEAD cache/${{ matrix.source.name }}/routes/**
-
       - name: Diff
         if: steps.detect-changes.outputs.changes_detected == 'true'
         id: diff
         run: |
-          GIT_DIFF=$(git diff cache/*/routes/**) 
+          # Use --cached to show staged changes including new files
+          GIT_DIFF=$(git diff --cached HEAD cache/${{ matrix.source.name }}/routes/**) 
           echo "text<<EOF" >> $GITHUB_OUTPUT
           echo "$GIT_DIFF" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Hi Gregor.
If I understood correctly, the reason why there are release notes with missing route information (like the example with `POST /images/edits`, `POST /images/generations`, etc. in #181, or the screenshot attached that is not showing messages about deleted files) is due to a bug in the `git diff` detection logic in the workflow.

<img width="912" height="642" alt="image" src="https://github.com/user-attachments/assets/3d60d5b8-716d-4469-883a-ab456da51143" />

Can you take a look at this approach where I'm staging all changes including new files in a previous step, and then, comparing them with a previous version.

Happy to help if you have feedback