### PR TITLE
refactor: migrate changes.yml to per-route file structure

### DIFF
--- a/changes/anthropic/v1/messages/post.yml
+++ b/changes/anthropic/v1/messages/post.yml
@@ -1,0 +1,22 @@
+- date: "2025-10-22"
+  change: added
+  target: request
+  breaking: false
+  deprecated: false
+  doc_only: false
+  note: "Added claude-haiku-4-5 model option"
+  paths:
+    - path: "requestBody.schema.properties.model.enum"
+      before: null
+      after: "claude-haiku-4-5"
+- date: "2025-10-22"
+  change: removed
+  target: request
+  breaking: true
+  deprecated: false
+  doc_only: false
+  note: "Removed claude-haiku-2-5 model option"
+  paths:
+    - path: "requestBody.schema.properties.model.enum"
+      before: "claude-haiku-2-5"
+      after: null


### PR DESCRIPTION
## Summary
- Migrates the 3 existing change records from `.github/workflows/changes.yml` to the new per-route structure at `changes/anthropic/v1/messages/post.yml`
- Establishes the `changes/<provider>/<route>/<method>.yml` directory convention

Phase 1 of #562.

## Changes
The old flat file had 3 records (add_property, add_option, remove_option) for `POST /v1/messages` on Anthropic. These are consolidated into 2 logical change records:
1. **added**: claude-haiku-4-5 model option
2. **removed**: claude-haiku-2-5 model option (breaking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)