### PR TITLE
feat: add append-changes script for per-route change tracking

### DIFF
--- a/scripts/append-changes.js
+++ b/scripts/append-changes.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import yaml from "js-yaml";
+
+const provider = process.argv[2];
+const changesJson = process.argv[3];
+
+if (!provider || !changesJson) {
+  console.error(
+    "Usage: node scripts/append-changes.js <provider> '<json-changes>'"
+  );
+  process.exit(1);
+}
+
+const changes = JSON.parse(changesJson);
+
+if (!Array.isArray(changes) || changes.length === 0) {
+  console.log("No changes to append");
+  process.exit(0);
+}
+
+// Group changes by route (method + path)
+const byRoute = new Map();
+for (const change of changes) {
+  const { route, ...record } = change;
+  if (!route) {
+    console.error("Change record missing 'route' field:", change);
+    continue;
+  }
+
+  // Parse "POST /v1/chat/completions" into method + path
+  const spaceIndex = route.indexOf(" ");
+  if (spaceIndex === -1) {
+    console.error("Invalid route format (expected 'METHOD /path'):", route);
+    continue;
+  }
+
+  const method = route.substring(0, spaceIndex).toLowerCase();
+  const path = route.substring(spaceIndex + 1);
+
+  const filePath = `changes/${provider}${path}/${method}.yml`;
+  if (!byRoute.has(filePath)) {
+    byRoute.set(filePath, []);
+  }
+  byRoute.get(filePath).push(record);
+}
+
+for (const [filePath, records] of byRoute) {
+  await mkdir(dirname(filePath), { recursive: true });
+
+  // Read existing records if file exists
+  let existing = [];
+  try {
+    const content = await readFile(filePath, "utf8");
+    existing = yaml.load(content) || [];
+  } catch (err) {
+    if (err.code !== "ENOENT") throw err;
+  }
+
+  const merged = [...existing, ...records];
+  await writeFile(filePath, yaml.dump(merged, { lineWidth: -1 }));
+  console.log(`${filePath}: appended ${records.length} record(s)`);
+}

--- a/test/append-changes.test.js
+++ b/test/append-changes.test.js
@@ -1,0 +1,173 @@
+import { readFile, rm, mkdir } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import test from "ava";
+import yaml from "js-yaml";
+
+const exec = promisify(execFile);
+const SCRIPT = "scripts/append-changes.js";
+const CHANGES_DIR = "changes";
+
+test.afterEach(async () => {
+  // Clean up changes directory after each test
+  await rm(CHANGES_DIR, { recursive: true, force: true });
+});
+
+test("creates new file for a single change", async (t) => {
+  const changes = [
+    {
+      route: "POST /v1/chat/completions",
+      date: "2026-02-19",
+      change: "changed",
+      target: "request",
+      breaking: true,
+      deprecated: false,
+      doc_only: false,
+      note: "sample_rate type changed",
+      paths: [
+        {
+          path: "schema.properties.sample_rate.type",
+          before: "number",
+          after: "integer",
+        },
+      ],
+    },
+  ];
+
+  await exec("node", [SCRIPT, "openai", JSON.stringify(changes)]);
+
+  const content = await readFile(
+    "changes/openai/v1/chat/completions/post.yml",
+    "utf8"
+  );
+  const records = yaml.load(content);
+
+  t.is(records.length, 1);
+  t.is(records[0].date, "2026-02-19");
+  t.is(records[0].change, "changed");
+  t.is(records[0].target, "request");
+  t.is(records[0].breaking, true);
+  t.is(records[0].paths[0].before, "number");
+  t.is(records[0].paths[0].after, "integer");
+  // route field should be stripped from the record
+  t.is(records[0].route, undefined);
+});
+
+test("appends to existing file", async (t) => {
+  // Create existing file
+  await mkdir("changes/openai/v1/models", { recursive: true });
+  const existing = [
+    {
+      date: "2026-01-01",
+      change: "added",
+      target: "response",
+      breaking: false,
+      deprecated: false,
+      doc_only: false,
+      note: "Added gpt-5 model",
+      paths: [],
+    },
+  ];
+  const { writeFile } = await import("node:fs/promises");
+  await writeFile(
+    "changes/openai/v1/models/get.yml",
+    yaml.dump(existing, { lineWidth: -1 })
+  );
+
+  const changes = [
+    {
+      route: "GET /v1/models",
+      date: "2026-02-19",
+      change: "added",
+      target: "response",
+      breaking: false,
+      deprecated: false,
+      doc_only: false,
+      note: "Added gpt-5-turbo model",
+      paths: [],
+    },
+  ];
+
+  await exec("node", [SCRIPT, "openai", JSON.stringify(changes)]);
+
+  const content = await readFile("changes/openai/v1/models/get.yml", "utf8");
+  const records = yaml.load(content);
+
+  t.is(records.length, 2);
+  t.is(records[0].note, "Added gpt-5 model");
+  t.is(records[1].note, "Added gpt-5-turbo model");
+});
+
+test("handles multiple routes in one call", async (t) => {
+  const changes = [
+    {
+      route: "POST /v1/chat/completions",
+      date: "2026-02-19",
+      change: "changed",
+      target: "request",
+      breaking: false,
+      deprecated: false,
+      doc_only: false,
+      note: "Added new parameter",
+      paths: [],
+    },
+    {
+      route: "GET /v1/models",
+      date: "2026-02-19",
+      change: "added",
+      target: "route",
+      breaking: false,
+      deprecated: false,
+      doc_only: false,
+      note: "New models endpoint",
+      paths: [],
+    },
+  ];
+
+  await exec("node", [SCRIPT, "openai", JSON.stringify(changes)]);
+
+  const chatContent = await readFile(
+    "changes/openai/v1/chat/completions/post.yml",
+    "utf8"
+  );
+  const modelsContent = await readFile(
+    "changes/openai/v1/models/get.yml",
+    "utf8"
+  );
+
+  t.is(yaml.load(chatContent).length, 1);
+  t.is(yaml.load(modelsContent).length, 1);
+});
+
+test("handles empty changes array", async (t) => {
+  const { stdout } = await exec("node", [SCRIPT, "openai", "[]"]);
+  t.true(stdout.includes("No changes to append"));
+});
+
+test("route-level add has no route field in output", async (t) => {
+  const changes = [
+    {
+      route: "POST /v1/new-endpoint",
+      date: "2026-02-19",
+      change: "added",
+      target: "route",
+      breaking: false,
+      deprecated: true,
+      doc_only: false,
+      note: "New deprecated endpoint",
+      paths: [],
+    },
+  ];
+
+  await exec("node", [SCRIPT, "openai", JSON.stringify(changes)]);
+
+  const content = await readFile(
+    "changes/openai/v1/new-endpoint/post.yml",
+    "utf8"
+  );
+  const records = yaml.load(content);
+
+  t.is(records[0].deprecated, true);
+  t.is(records[0].route, undefined);
+});


### PR DESCRIPTION
## Summary
- Adds `scripts/append-changes.js` that takes a provider name + JSON change records and writes them to per-route YAML files
- Groups changes by route, creates directories as needed, appends to existing files
- Strips the `route` field from records (it's implied by the file path)
- Includes 5 tests covering: new file creation, appending, multiple routes, empty input, field handling

Phase 2 of #562.

## Test plan
- [x] `npx ava test/append-changes.test.js` — 5 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)