### PR TITLE
refactor: consolidate workflow into single script per provider

### DIFF
--- a/.github/workflows/check-for-api-changes.yml
+++ b/.github/workflows/check-for-api-changes.yml
@@ -13,8 +13,7 @@ on:
       - ".github/workflows/check-for-api-changes.yml"
 
 jobs:
-  # Job 1: Per-provider detection of changed routes
-  detect:
+  check:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -52,31 +51,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Create cache directory
-        run: mkdir -p cache/${{ matrix.source.name }}
-
-      - name: Download API specification
-        id: detect-first-run
-        run: |
-          # Check if this is the first run (no previous spec exists)
-          if [ ! -f "cache/${{ matrix.source.name }}/${{ matrix.source.filename }}" ]; then
-            echo "first_run=true" >> $GITHUB_OUTPUT
-            echo "New specification detected"
-            exit 0
-          fi
-
-      - name: Download
-        id: download
-        run: |
-          output_file="cache/${{ matrix.source.name }}/${{ matrix.source.filename }}"
-          curl -s "${{ matrix.source.openapi_url }}" -o "$output_file"
-          echo "file_path=$output_file" >> $GITHUB_OUTPUT
-
-      - name: Sort keys in OpenAPI specification
+      - name: Install yq
         run: |
           wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           chmod +x /usr/local/bin/yq
-          yq -i -P 'sort_keys(..) | explode(.)' ${{ steps.download.outputs.file_path }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -87,17 +65,25 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Format specification
-        run: npx prettier --write "${{ steps.download.outputs.file_path }}"
-
-      - name: Generate route files
+      - name: Check for changes
+        id: check
+        env:
+          OPENAI_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
         run: |
-          rm -rf cache/${{ matrix.source.name }}/routes
-          node scripts/dereference-and-split-into-route-files.js ${{ matrix.source.name }}
+          node scripts/check-for-changes.js "${{ matrix.source.name }}" "${{ matrix.source.openapi_url }}" "${{ matrix.source.filename }}" > result.json
+          cat result.json
 
-      # If this is the first run, create PR with the initial spec
+          echo "has_changes=$(jq -r '.has_changes' result.json)" >> $GITHUB_OUTPUT
+          echo "first_run=$(jq -r '.first_run' result.json)" >> $GITHUB_OUTPUT
+          echo "title=$(jq -r '.title' result.json)" >> $GITHUB_OUTPUT
+
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          jq -r '.body' result.json >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      # First run: create PR with the initial spec
       - name: Create initial PR
-        if: steps.detect-first-run.outputs.first_run == 'true'
+        if: steps.check.outputs.first_run == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           title: "feat: add initial ${{ matrix.source.name }} API specification"
@@ -111,323 +97,20 @@ jobs:
             provider:${{ matrix.source.name }}
           commit-message: "feat: add initial ${{ matrix.source.name }} API specification"
 
-      - name: Stage changes
-        if: steps.detect-first-run.outputs.first_run != 'true'
-        run: git add cache/${{ matrix.source.name }}/
-
-      - name: Detect changes
-        if: steps.detect-first-run.outputs.first_run != 'true'
-        id: detect-changes
-        run: |
-          if ! git diff --quiet --cached HEAD cache/${{ matrix.source.name }}/routes/**; then
-            echo "changes_detected=true" >> $GITHUB_OUTPUT
-          else
-            echo "changes_detected=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Build changed routes list
-        if: steps.detect-changes.outputs.changes_detected == 'true'
-        run: |
-          PROVIDER="${{ matrix.source.name }}"
-          mkdir -p route-changes
-
-          # List changed route files with status (A=added, M=modified, D=deleted, R=renamed)
-          # For renames (R###), git outputs: status\told_path\tnew_path
-          git diff --cached --name-status HEAD "cache/${PROVIDER}/routes/**" | while IFS=$'\t' read -r status old_file new_file; do
-            # For renames, use new_file; for other statuses, old_file is the only path
-            if [[ "$status" == R* ]]; then
-              file="$new_file"
-              # Treat renames as modifications for downstream processing
-              status="M"
-            else
-              file="$old_file"
-            fi
-
-            # Derive route: cache/openai/routes/chat/completions/post.json → POST /chat/completions
-            # Decode _QMARK_→? and _EQ_→= for display
-            ROUTE_PATH=$(echo "$file" | sed "s|cache/${PROVIDER}/routes/||" | sed 's|/[^/]*\.json$||' | sed 's|_QMARK_|?|g' | sed 's|_EQ_|=|g')
-            METHOD=$(basename "$file" .json | tr '[:lower:]' '[:upper:]')
-            ROUTE="${METHOD} /${ROUTE_PATH}"
-
-            # Sanitize file path for artifact name (replace special chars)
-            SAFE_NAME=$(echo "$file" | sed "s|cache/${PROVIDER}/routes/||" | sed 's|/|--|g' | sed 's|_QMARK_|_|g' | sed 's|_EQ_|_|g' | sed 's|\.json$||')
-
-            echo "{\"provider\":\"${PROVIDER}\",\"file\":\"${file}\",\"status\":\"${status}\",\"route\":\"${ROUTE}\",\"safe_name\":\"${SAFE_NAME}\"}" > "route-changes/${SAFE_NAME}.json"
-          done
-
-          echo "Changed routes:"
-          cat route-changes/*.json 2>/dev/null || echo "none"
-
-      - name: Upload new cache
-        if: steps.detect-changes.outputs.changes_detected == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: cache-${{ matrix.source.name }}
-          path: cache/${{ matrix.source.name }}/
-
-      - name: Upload changed routes list
-        if: steps.detect-changes.outputs.changes_detected == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: changed-routes-${{ matrix.source.name }}
-          path: route-changes/
-
-      - name: Summary
-        run: |
-          if [ "${{ steps.detect-first-run.outputs.first_run }}" = "true" ]; then
-            echo "✅ First run completed - ${{ matrix.source.name }} API specification saved"
-          elif [ "${{ steps.detect-changes.outputs.changes_detected }}" = "true" ]; then
-            echo "🔄 Changes detected in ${{ matrix.source.name }}"
-          else
-            echo "✅ No changes detected - ${{ matrix.source.name }} is up to date"
-          fi
-
-  # Job 2: Collect all changed routes into a single matrix
-  build-matrix:
-    needs: detect
-    runs-on: ubuntu-latest
-    outputs:
-      route_matrix: ${{ steps.matrix.outputs.routes }}
-      provider_matrix: ${{ steps.matrix.outputs.providers }}
-      has_changes: ${{ steps.matrix.outputs.has_changes }}
-    steps:
-      - name: Download changed routes artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: changed-routes-*
-          path: all-changes/
-
-      - name: Build matrix
-        id: matrix
-        run: |
-          ROUTES="[]"
-          PROVIDERS="[]"
-
-          # Process each provider's changed routes
-          for dir in all-changes/changed-routes-*/; do
-            [ -d "$dir" ] || continue
-            for f in "$dir"*.json; do
-              [ -f "$f" ] || continue
-              ENTRY=$(cat "$f")
-              ROUTES=$(echo "$ROUTES" | jq --argjson entry "$ENTRY" '. + [$entry]')
-              PROVIDER=$(echo "$ENTRY" | jq -r '.provider')
-              PROVIDERS=$(echo "$PROVIDERS" | jq --arg p "$PROVIDER" 'if index($p) then . else . + [$p] end')
-            done
-          done
-
-          ROUTE_COUNT=$(echo "$ROUTES" | jq length)
-          echo "Found $ROUTE_COUNT changed routes across $(echo "$PROVIDERS" | jq length) providers"
-          echo "$ROUTES" | jq .
-
-          echo "routes=$(echo "$ROUTES" | jq -c .)" >> $GITHUB_OUTPUT
-          echo "providers=$(echo "$PROVIDERS" | jq -c .)" >> $GITHUB_OUTPUT
-
-          if [ "$ROUTE_COUNT" -gt 0 ]; then
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-          fi
-
-  # Job 3: Analyze each changed route individually
-  analyze:
-    needs: build-matrix
-    if: needs.build-matrix.outputs.has_changes == 'true'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        route: ${{ fromJson(needs.build-matrix.outputs.route_matrix) }}
-    steps:
-      - name: Checkout repository (old state)
-        uses: actions/checkout@v6
-
-      - name: Download new cache
-        uses: actions/download-artifact@v4
-        with:
-          name: cache-${{ matrix.route.provider }}
-          path: new-cache/
-
-      - name: Get today's date
-        id: today
-        run: echo "date=$(date -u +%Y-%m-%d)" >> $GITHUB_OUTPUT
-
-      - name: Prepare old and new spec files
-        id: specs
-        run: |
-          PROVIDER="${{ matrix.route.provider }}"
-          FILE="${{ matrix.route.file }}"
-          STATUS="${{ matrix.route.status }}"
-          RELATIVE="${FILE#cache/${PROVIDER}/}"
-
-          OLD_FILE="$FILE"
-          NEW_FILE="new-cache/${RELATIVE}"
-
-          # Check which files actually exist
-          [ "$STATUS" != "A" ] && [ -f "$OLD_FILE" ] && echo "old_file=$OLD_FILE" >> $GITHUB_OUTPUT
-          [ "$STATUS" != "D" ] && [ -f "$NEW_FILE" ] && echo "new_file=$NEW_FILE" >> $GITHUB_OUTPUT
-
-          echo "status=$STATUS" >> $GITHUB_OUTPUT
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: package.json
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Analyze route change
-        id: analyze
-        env:
-          OPENAI_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
-        run: |
-          ARGS=("${{ matrix.route.status }}" "${{ matrix.route.route }}" "${{ steps.today.outputs.date }}")
-          [ -n "${{ steps.specs.outputs.old_file }}" ] && ARGS+=("${{ steps.specs.outputs.old_file }}") || ARGS+=("")
-          [ -n "${{ steps.specs.outputs.new_file }}" ] && ARGS+=("${{ steps.specs.outputs.new_file }}") || ARGS+=("")
-
-          RESULT=$(node scripts/analyze-route-change.js "${ARGS[@]}")
-          echo "Analysis result:"
-          echo "$RESULT" | jq .
-
-          # Save to file for artifact upload
-          echo "$RESULT" > analysis-result.json
-
-      - name: Upload analysis result
-        uses: actions/upload-artifact@v4
-        with:
-          name: analysis-${{ matrix.route.provider }}--${{ matrix.route.safe_name }}
-          path: analysis-result.json
-
-  # Job 4: Collect results and create PR per provider
-  update:
-    needs: [build-matrix, analyze]
-    if: needs.build-matrix.outputs.has_changes == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    strategy:
-      fail-fast: false
-      matrix:
-        provider: ${{ fromJson(needs.build-matrix.outputs.provider_matrix) }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: package.json
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Download new cache
-        uses: actions/download-artifact@v4
-        with:
-          name: cache-${{ matrix.provider }}
-          path: new-cache/
-
-      - name: Copy updated cache to working tree
-        run: |
-          rm -rf cache/${{ matrix.provider }}/
-          cp -r new-cache/ cache/${{ matrix.provider }}/
-
-      - name: Download analysis results
-        uses: actions/download-artifact@v4
-        with:
-          pattern: analysis-${{ matrix.provider }}--*
-          path: analysis-results/
-
-      - name: Collect change records and create PR description
-        id: collect
-        run: |
-          ALL_CHANGES="[]"
-          ALL_SUMMARIES=""
-
-          # Merge all analysis results for this provider
-          for dir in analysis-results/analysis-${{ matrix.provider }}--*/; do
-            [ -d "$dir" ] || continue
-            RESULT=$(cat "${dir}analysis-result.json")
-            CHANGES=$(echo "$RESULT" | jq '.changes')
-            SUMMARY=$(echo "$RESULT" | jq -r '.summary')
-
-            ALL_CHANGES=$(echo "$ALL_CHANGES" | jq --argjson c "$CHANGES" '. + $c')
-            ALL_SUMMARIES="${ALL_SUMMARIES}- ${SUMMARY}\n"
-          done
-
-          CHANGE_COUNT=$(echo "$ALL_CHANGES" | jq length)
-          echo "Collected $CHANGE_COUNT change records"
-
-          # Build PR title
-          if [ "$CHANGE_COUNT" -eq 1 ]; then
-            TITLE=$(echo "$ALL_CHANGES" | jq -r '.[0].note' | head -c 100)
-          else
-            TITLE="update ${{ matrix.provider }} API specification (${CHANGE_COUNT} changes)"
-          fi
-
-          # Build PR body from change records
-          BODY=""
-          BREAKING=$(echo "$ALL_CHANGES" | jq '[.[] | select(.breaking == true)]')
-          FEATURES=$(echo "$ALL_CHANGES" | jq '[.[] | select(.breaking == false and .change != "removed" and .doc_only == false)]')
-          FIXES=$(echo "$ALL_CHANGES" | jq '[.[] | select(.doc_only == true)]')
-
-          if [ "$(echo "$BREAKING" | jq length)" -gt 0 ]; then
-            BODY="${BODY}### Breaking changes\n\n"
-            for row in $(echo "$BREAKING" | jq -r '.[] | @base64'); do
-              ROUTE=$(echo "$row" | base64 -d | jq -r '.route')
-              NOTE=$(echo "$row" | base64 -d | jq -r '.note')
-              BODY="${BODY}- **${ROUTE}**: ${NOTE}\n"
-            done
-            BODY="${BODY}\n"
-          fi
-
-          if [ "$(echo "$FEATURES" | jq length)" -gt 0 ]; then
-            BODY="${BODY}### New features\n\n"
-            for row in $(echo "$FEATURES" | jq -r '.[] | @base64'); do
-              ROUTE=$(echo "$row" | base64 -d | jq -r '.route')
-              NOTE=$(echo "$row" | base64 -d | jq -r '.note')
-              BODY="${BODY}- **${ROUTE}**: ${NOTE}\n"
-            done
-            BODY="${BODY}\n"
-          fi
-
-          if [ "$(echo "$FIXES" | jq length)" -gt 0 ]; then
-            BODY="${BODY}### Documentation fixes\n\n"
-            for row in $(echo "$FIXES" | jq -r '.[] | @base64'); do
-              ROUTE=$(echo "$row" | base64 -d | jq -r '.route')
-              NOTE=$(echo "$row" | base64 -d | jq -r '.note')
-              BODY="${BODY}- **${ROUTE}**: ${NOTE}\n"
-            done
-          fi
-
-          # Save outputs
-          echo "title=${TITLE}" >> $GITHUB_OUTPUT
-
-          echo "body<<EOF" >> $GITHUB_OUTPUT
-          echo -e "$BODY" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-          echo "changes=$(echo "$ALL_CHANGES" | jq -c .)" >> $GITHUB_OUTPUT
-
-      - name: Append change records
-        run: |
-          node scripts/append-changes.js "${{ matrix.provider }}" '${{ steps.collect.outputs.changes }}'
-
+      # Changes detected: create update PR
       - name: Create Pull Request
+        if: steps.check.outputs.has_changes == 'true'
         id: create-pr
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "Update ${{ matrix.provider }} API specification"
-          title: ${{ steps.collect.outputs.title }}
-          body: ${{ steps.collect.outputs.body }}
-          branch: update/${{ matrix.provider }}
+          commit-message: "Update ${{ matrix.source.name }} API specification"
+          title: ${{ steps.check.outputs.title }}
+          body: ${{ steps.check.outputs.body }}
+          branch: update/${{ matrix.source.name }}
           delete-branch: true
           labels: |
-            provider:${{ matrix.provider }}
+            provider:${{ matrix.source.name }}
           assignees: ${{ github.repository_owner }}
 
       # Auto-merge the PR
@@ -445,4 +128,11 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Summary
-        run: echo "🔄 PR created for ${{ matrix.provider }} - ${{ steps.create-pr.outputs.pull-request-url }}"
+        run: |
+          if [ "${{ steps.check.outputs.first_run }}" = "true" ]; then
+            echo "✅ First run completed - ${{ matrix.source.name }} API specification saved"
+          elif [ "${{ steps.check.outputs.has_changes }}" = "true" ]; then
+            echo "🔄 Changes detected in ${{ matrix.source.name }}"
+          else
+            echo "✅ No changes detected - ${{ matrix.source.name }} is up to date"
+          fi

--- a/scripts/analyze-route-change.js
+++ b/scripts/analyze-route-change.js
@@ -21,6 +21,8 @@
 
 import { readFile } from "node:fs/promises";
 
+import { analyzeRouteChange } from "./lib/analyze-route-change.js";
+
 const status = process.argv[2];
 const route = process.argv[3];
 const date = process.argv[4];
@@ -34,11 +36,6 @@ if (!status || !route || !date) {
   process.exit(1);
 }
 
-if (!process.env.OPENAI_API_KEY) {
-  console.error("OPENAI_API_KEY environment variable is required");
-  process.exit(1);
-}
-
 async function readFileOrEmpty(filePath) {
   if (!filePath) return "";
   try {
@@ -48,139 +45,15 @@ async function readFileOrEmpty(filePath) {
   }
 }
 
-async function callOpenAI(prompt, schema) {
-  const response = await fetch("https://api.openai.com/v1/chat/completions", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      model: "gpt-5",
-      messages: [{ role: "user", content: prompt }],
-      response_format: {
-        type: "json_schema",
-        json_schema: { name: "route_analysis", schema },
-      },
-      temperature: 0.1,
-    }),
-  });
+const oldContent = await readFileOrEmpty(oldFile);
+const newContent = await readFileOrEmpty(newFile);
 
-  if (!response.ok) {
-    const errorBody = await response.text();
-    throw new Error(
-      `OpenAI API error: ${response.status} ${response.statusText} - ${errorBody}`
-    );
-  }
+const result = await analyzeRouteChange({
+  status,
+  route,
+  date,
+  oldContent,
+  newContent,
+});
 
-  const data = await response.json();
-  return JSON.parse(data.choices[0].message.content);
-}
-
-const SCHEMA = {
-  type: "object",
-  properties: {
-    changes: {
-      type: "array",
-      items: {
-        type: "object",
-        properties: {
-          change: { type: "string", enum: ["added", "changed", "removed"] },
-          target: { type: "string", enum: ["route", "request", "response"] },
-          breaking: { type: "boolean" },
-          deprecated: { type: "boolean" },
-          doc_only: { type: "boolean" },
-          note: { type: "string" },
-          paths: {
-            type: "array",
-            items: {
-              type: "object",
-              properties: {
-                path: { type: "string" },
-                before: { type: "string" },
-                after: { type: "string" },
-              },
-              required: ["path", "before", "after"],
-              additionalProperties: false,
-            },
-          },
-        },
-        required: [
-          "change",
-          "target",
-          "breaking",
-          "deprecated",
-          "doc_only",
-          "note",
-          "paths",
-        ],
-        additionalProperties: false,
-      },
-    },
-    summary: {
-      type: "string",
-      description: "One-line summary of changes to this route (max 100 chars)",
-    },
-  },
-  required: ["changes", "summary"],
-  additionalProperties: false,
-};
-
-let prompt;
-if (status === "A") {
-  const newContent = await readFileOrEmpty(newFile);
-  prompt = `A new API route was added: ${route}
-
-Here is the full dereferenced OpenAPI specification for this route:
-
-${newContent}
-
-Produce change records for this addition. Since the entire route is new, create a single record with change "added" and target "route". Include a brief note describing what this endpoint does. The paths array should be empty for route-level additions.
-
-Also provide a one-line summary (max 100 chars).`;
-} else if (status === "D") {
-  const oldContent = await readFileOrEmpty(oldFile);
-  prompt = `An API route was removed: ${route}
-
-Here was the full dereferenced OpenAPI specification for this route:
-
-${oldContent}
-
-Produce change records for this removal. Create a single record with change "removed", target "route", breaking true. Include a brief note describing what this endpoint was. The paths array should be empty for route-level removals.
-
-Also provide a one-line summary (max 100 chars).`;
-} else {
-  const oldContent = await readFileOrEmpty(oldFile);
-  const newContent = await readFileOrEmpty(newFile);
-  prompt = `An API route was modified: ${route}
-
-Here is the OLD dereferenced specification:
-
-${oldContent}
-
-Here is the NEW dereferenced specification:
-
-${newContent}
-
-Analyze the differences and produce change records. For each logical change, create a record with:
-- change: "added" (new property/option), "changed" (type/value change), or "removed" (property/option gone)
-- target: "request" or "response"
-- breaking: true if the change could break existing consumers
-- deprecated: true if something was marked as deprecated
-- doc_only: true if only descriptions/examples changed, not schema structure
-- note: human-readable description of the change
-- paths: array of {path, before, after} with JSON-path-like notation relative to the route spec. Use "null" string for before on additions and after on removals.
-
-Also provide a one-line summary of all changes to this route (max 100 chars).`;
-}
-
-const result = await callOpenAI(prompt, SCHEMA);
-
-// Inject route and date into each change record
-for (const change of result.changes) {
-  change.route = route;
-  change.date = date;
-}
-
-// Output JSON to stdout
 console.log(JSON.stringify(result));

--- a/scripts/append-changes.js
+++ b/scripts/append-changes.js
@@ -1,9 +1,6 @@
 #!/usr/bin/env node
 
-import { readFile, writeFile, mkdir } from "node:fs/promises";
-import { dirname } from "node:path";
-
-import yaml from "js-yaml";
+import { appendChanges } from "./lib/append-changes.js";
 
 const provider = process.argv[2];
 const changesJson = process.argv[3];
@@ -16,51 +13,4 @@ if (!provider || !changesJson) {
 }
 
 const changes = JSON.parse(changesJson);
-
-if (!Array.isArray(changes) || changes.length === 0) {
-  console.log("No changes to append");
-  process.exit(0);
-}
-
-// Group changes by route (method + path)
-const byRoute = new Map();
-for (const change of changes) {
-  const { route, ...record } = change;
-  if (!route) {
-    console.error("Change record missing 'route' field:", change);
-    continue;
-  }
-
-  // Parse "POST /v1/chat/completions" into method + path
-  const spaceIndex = route.indexOf(" ");
-  if (spaceIndex === -1) {
-    console.error("Invalid route format (expected 'METHOD /path'):", route);
-    continue;
-  }
-
-  const method = route.substring(0, spaceIndex).toLowerCase();
-  const path = route.substring(spaceIndex + 1);
-
-  const filePath = `changes/${provider}${path}/${method}.yml`;
-  if (!byRoute.has(filePath)) {
-    byRoute.set(filePath, []);
-  }
-  byRoute.get(filePath).push(record);
-}
-
-for (const [filePath, records] of byRoute) {
-  await mkdir(dirname(filePath), { recursive: true });
-
-  // Read existing records if file exists
-  let existing = [];
-  try {
-    const content = await readFile(filePath, "utf8");
-    existing = yaml.load(content) || [];
-  } catch (err) {
-    if (err.code !== "ENOENT") throw err;
-  }
-
-  const merged = [...existing, ...records];
-  await writeFile(filePath, yaml.dump(merged, { lineWidth: -1 }));
-  console.log(`${filePath}: appended ${records.length} record(s)`);
-}
+await appendChanges(provider, changes);

--- a/scripts/check-for-changes.js
+++ b/scripts/check-for-changes.js
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+
+/**
+ * Orchestrator script that detects, analyzes, and records API changes for a provider.
+ *
+ * Usage:
+ *   node scripts/check-for-changes.js <provider> <openapi_url> <filename>
+ *
+ * Arguments:
+ *   provider    - e.g. "openai"
+ *   openapi_url - URL to download the OpenAPI spec from
+ *   filename    - local filename for the spec, e.g. "openapi.yml"
+ *
+ * Environment:
+ *   OPENAI_API_KEY - OpenAI API key (required when changes are detected)
+ *
+ * Outputs JSON to stdout:
+ *   { has_changes: boolean, first_run: boolean, title: string, body: string }
+ *
+ * Progress messages are written to stderr.
+ */
+
+import { readFile, writeFile, mkdir, rm, glob } from "node:fs/promises";
+import { dirname, basename } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import yaml from "js-yaml";
+import $RefParser from "@apidevtools/json-schema-ref-parser";
+
+import { analyzeRouteChange } from "./lib/analyze-route-change.js";
+import { appendChanges } from "./lib/append-changes.js";
+
+const exec = promisify(execFile);
+
+const provider = process.argv[2];
+const openapiUrl = process.argv[3];
+const filename = process.argv[4];
+
+if (!provider || !openapiUrl || !filename) {
+  console.error(
+    "Usage: node scripts/check-for-changes.js <provider> <openapi_url> <filename>"
+  );
+  process.exit(1);
+}
+
+// --- Step 1: Read existing route files into a Map ---
+const oldRoutes = new Map();
+for await (const filePath of glob(`cache/${provider}/routes/**/*.json`)) {
+  const relativePath = filePath.replace(`cache/${provider}/routes/`, "");
+  const content = await readFile(filePath, "utf8");
+  oldRoutes.set(relativePath, content);
+}
+console.error(`Read ${oldRoutes.size} existing route files`);
+
+// --- Step 2: Detect first run ---
+const specPath = `cache/${provider}/${filename}`;
+let isFirstRun = false;
+try {
+  await readFile(specPath);
+} catch {
+  isFirstRun = true;
+}
+
+// --- Step 3: Download fresh spec ---
+await mkdir(`cache/${provider}`, { recursive: true });
+console.error(`Downloading spec from ${openapiUrl}`);
+const response = await fetch(openapiUrl);
+if (!response.ok) {
+  throw new Error(
+    `Failed to download spec: ${response.status} ${response.statusText}`
+  );
+}
+const specContent = await response.text();
+await writeFile(specPath, specContent);
+
+// --- Step 4: Sort keys and format ---
+console.error("Sorting keys with yq");
+await exec("yq", ["-i", "-P", "sort_keys(..) | explode(.)", specPath]);
+
+console.error("Formatting with prettier");
+await exec("npx", ["prettier", "--write", specPath]);
+
+// --- Step 5: Dereference and split into route files ---
+console.error("Dereferencing and splitting into route files");
+await rm(`cache/${provider}/routes`, { recursive: true, force: true });
+
+const processedContent = await readFile(specPath, "utf8");
+const schema = specPath.endsWith(".json")
+  ? JSON.parse(processedContent)
+  : yaml.load(processedContent);
+
+removeXPrefix(schema);
+await $RefParser.dereference(schema);
+
+const newRoutes = new Map();
+if (schema.paths) {
+  for (const [path, operations] of Object.entries(schema.paths)) {
+    for (const [method, operation] of Object.entries(operations)) {
+      const safePath = path.replaceAll("?", "_QMARK_").replaceAll("=", "_EQ_");
+      const relativePath = `${safePath.slice(1)}/${method}.json`;
+      const content = JSON.stringify(operation, null, 2) + "\n";
+      newRoutes.set(relativePath, content);
+
+      const routeDir = `cache/${provider}/routes${safePath}`;
+      await mkdir(routeDir, { recursive: true });
+      await writeFile(`${routeDir}/${method}.json`, content);
+    }
+  }
+}
+console.error(`Generated ${newRoutes.size} route files`);
+
+// --- Step 6: First run — skip analysis ---
+if (isFirstRun) {
+  console.error("First run detected, skipping analysis");
+  console.log(
+    JSON.stringify({ has_changes: false, first_run: true, title: "", body: "" })
+  );
+  process.exit(0);
+}
+
+// --- Step 7: Compare old vs new routes ---
+const changedRoutes = [];
+
+for (const [relativePath, newContent] of newRoutes) {
+  const oldContent = oldRoutes.get(relativePath);
+  if (!oldContent) {
+    changedRoutes.push({
+      relativePath,
+      status: "A",
+      oldContent: "",
+      newContent,
+    });
+  } else if (oldContent !== newContent) {
+    changedRoutes.push({
+      relativePath,
+      status: "M",
+      oldContent,
+      newContent,
+    });
+  }
+}
+
+for (const [relativePath, oldContent] of oldRoutes) {
+  if (!newRoutes.has(relativePath)) {
+    changedRoutes.push({
+      relativePath,
+      status: "D",
+      oldContent,
+      newContent: "",
+    });
+  }
+}
+
+if (changedRoutes.length === 0) {
+  console.error("No changes detected");
+  console.log(
+    JSON.stringify({
+      has_changes: false,
+      first_run: false,
+      title: "",
+      body: "",
+    })
+  );
+  process.exit(0);
+}
+
+console.error(`Found ${changedRoutes.length} changed routes`);
+
+// --- Step 8: Analyze each changed route ---
+const today = new Date().toISOString().split("T")[0];
+
+async function withConcurrency(items, limit, fn) {
+  const results = [];
+  const executing = new Set();
+
+  for (const item of items) {
+    const p = fn(item).then((result) => {
+      executing.delete(p);
+      return result;
+    });
+    executing.add(p);
+    results.push(p);
+
+    if (executing.size >= limit) {
+      await Promise.race(executing);
+    }
+  }
+
+  return Promise.all(results);
+}
+
+function deriveRoute(relativePath) {
+  const parts = relativePath.split("/");
+  const methodFile = parts.pop();
+  const method = basename(methodFile, ".json").toUpperCase();
+  const routePath =
+    "/" +
+    parts
+      .join("/")
+      .replaceAll("_QMARK_", "?")
+      .replaceAll("_EQ_", "=");
+  return `${method} ${routePath}`;
+}
+
+const analysisResults = await withConcurrency(
+  changedRoutes,
+  5,
+  async ({ relativePath, status, oldContent, newContent }) => {
+    const route = deriveRoute(relativePath);
+    console.error(`Analyzing: ${route} (${status})`);
+
+    const result = await analyzeRouteChange({
+      status,
+      route,
+      date: today,
+      oldContent,
+      newContent,
+    });
+    return result;
+  }
+);
+
+const allChanges = [];
+for (const result of analysisResults) {
+  allChanges.push(...result.changes);
+}
+
+// --- Step 9: Append change records ---
+await appendChanges(provider, allChanges);
+
+// --- Step 10: Build PR title and body ---
+let title;
+if (allChanges.length === 1) {
+  title = allChanges[0].note.substring(0, 100);
+} else {
+  title = `update ${provider} API specification (${allChanges.length} changes)`;
+}
+
+let body = "";
+const breaking = allChanges.filter((c) => c.breaking);
+const features = allChanges.filter(
+  (c) => !c.breaking && c.change !== "removed" && !c.doc_only
+);
+const docFixes = allChanges.filter((c) => c.doc_only);
+
+if (breaking.length > 0) {
+  body += "### Breaking changes\n\n";
+  for (const c of breaking) {
+    body += `- **${c.route}**: ${c.note}\n`;
+  }
+  body += "\n";
+}
+
+if (features.length > 0) {
+  body += "### New features\n\n";
+  for (const c of features) {
+    body += `- **${c.route}**: ${c.note}\n`;
+  }
+  body += "\n";
+}
+
+if (docFixes.length > 0) {
+  body += "### Documentation fixes\n\n";
+  for (const c of docFixes) {
+    body += `- **${c.route}**: ${c.note}\n`;
+  }
+}
+
+// --- Step 11: Output result ---
+console.log(JSON.stringify({ has_changes: true, first_run: false, title, body }));
+
+// --- Helpers ---
+
+function removeXPrefix(obj) {
+  if (obj === null || typeof obj !== "object") {
+    return;
+  }
+
+  if (Array.isArray(obj)) {
+    for (const item of obj) {
+      removeXPrefix(item);
+    }
+  } else {
+    for (const [key, value] of Object.entries(obj)) {
+      if (key.startsWith("x-")) {
+        delete obj[key];
+      } else {
+        removeXPrefix(value);
+      }
+    }
+  }
+}

--- a/scripts/lib/analyze-route-change.js
+++ b/scripts/lib/analyze-route-change.js
@@ -1,0 +1,158 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import yaml from "js-yaml";
+
+const SCHEMA = {
+  type: "object",
+  properties: {
+    changes: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          change: { type: "string", enum: ["added", "changed", "removed"] },
+          target: { type: "string", enum: ["route", "request", "response"] },
+          breaking: { type: "boolean" },
+          deprecated: { type: "boolean" },
+          doc_only: { type: "boolean" },
+          note: { type: "string" },
+          paths: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                path: { type: "string" },
+                before: { type: "string" },
+                after: { type: "string" },
+              },
+              required: ["path", "before", "after"],
+              additionalProperties: false,
+            },
+          },
+        },
+        required: [
+          "change",
+          "target",
+          "breaking",
+          "deprecated",
+          "doc_only",
+          "note",
+          "paths",
+        ],
+        additionalProperties: false,
+      },
+    },
+    summary: {
+      type: "string",
+      description: "One-line summary of changes to this route (max 100 chars)",
+    },
+  },
+  required: ["changes", "summary"],
+  additionalProperties: false,
+};
+
+async function callOpenAI(prompt, schema) {
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "gpt-5",
+      messages: [{ role: "user", content: prompt }],
+      response_format: {
+        type: "json_schema",
+        json_schema: { name: "route_analysis", schema },
+      },
+      temperature: 0.1,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(
+      `OpenAI API error: ${response.status} ${response.statusText} - ${errorBody}`
+    );
+  }
+
+  const data = await response.json();
+  return JSON.parse(data.choices[0].message.content);
+}
+
+/**
+ * Analyzes a single route change by comparing old and new content.
+ *
+ * @param {object} options
+ * @param {string} options.status - A (added), M (modified), D (deleted)
+ * @param {string} options.route - e.g. "POST /v1/chat/completions"
+ * @param {string} options.date - ISO date, e.g. "2026-02-19"
+ * @param {string} options.oldContent - old route spec content (empty for additions)
+ * @param {string} options.newContent - new route spec content (empty for deletions)
+ * @returns {Promise<{changes: Array, summary: string}>}
+ */
+export async function analyzeRouteChange({
+  status,
+  route,
+  date,
+  oldContent,
+  newContent,
+}) {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error("OPENAI_API_KEY environment variable is required");
+  }
+
+  let prompt;
+  if (status === "A") {
+    prompt = `A new API route was added: ${route}
+
+Here is the full dereferenced OpenAPI specification for this route:
+
+${newContent}
+
+Produce change records for this addition. Since the entire route is new, create a single record with change "added" and target "route". Include a brief note describing what this endpoint does. The paths array should be empty for route-level additions.
+
+Also provide a one-line summary (max 100 chars).`;
+  } else if (status === "D") {
+    prompt = `An API route was removed: ${route}
+
+Here was the full dereferenced OpenAPI specification for this route:
+
+${oldContent}
+
+Produce change records for this removal. Create a single record with change "removed", target "route", breaking true. Include a brief note describing what this endpoint was. The paths array should be empty for route-level removals.
+
+Also provide a one-line summary (max 100 chars).`;
+  } else {
+    prompt = `An API route was modified: ${route}
+
+Here is the OLD dereferenced specification:
+
+${oldContent}
+
+Here is the NEW dereferenced specification:
+
+${newContent}
+
+Analyze the differences and produce change records. For each logical change, create a record with:
+- change: "added" (new property/option), "changed" (type/value change), or "removed" (property/option gone)
+- target: "request" or "response"
+- breaking: true if the change could break existing consumers
+- deprecated: true if something was marked as deprecated
+- doc_only: true if only descriptions/examples changed, not schema structure
+- note: human-readable description of the change
+- paths: array of {path, before, after} with JSON-path-like notation relative to the route spec. Use "null" string for before on additions and after on removals.
+
+Also provide a one-line summary of all changes to this route (max 100 chars).`;
+  }
+
+  const result = await callOpenAI(prompt, SCHEMA);
+
+  for (const change of result.changes) {
+    change.route = route;
+    change.date = date;
+  }
+
+  return result;
+}

--- a/scripts/lib/append-changes.js
+++ b/scripts/lib/append-changes.js
@@ -1,0 +1,60 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import yaml from "js-yaml";
+
+/**
+ * Appends change records to YAML files grouped by route.
+ *
+ * @param {string} provider - e.g. "openai"
+ * @param {Array} changes - array of change records, each with a `route` field
+ */
+export async function appendChanges(provider, changes) {
+  if (!Array.isArray(changes) || changes.length === 0) {
+    console.log("No changes to append");
+    return;
+  }
+
+  // Group changes by route (method + path)
+  const byRoute = new Map();
+  for (const change of changes) {
+    const { route, ...record } = change;
+    if (!route) {
+      console.error("Change record missing 'route' field:", change);
+      continue;
+    }
+
+    // Parse "POST /v1/chat/completions" into method + path
+    const spaceIndex = route.indexOf(" ");
+    if (spaceIndex === -1) {
+      console.error("Invalid route format (expected 'METHOD /path'):", route);
+      continue;
+    }
+
+    const method = route.substring(0, spaceIndex).toLowerCase();
+    const path = route.substring(spaceIndex + 1);
+
+    const filePath = `changes/${provider}${path}/${method}.yml`;
+    if (!byRoute.has(filePath)) {
+      byRoute.set(filePath, []);
+    }
+    byRoute.get(filePath).push(record);
+  }
+
+  for (const [filePath, records] of byRoute) {
+    await mkdir(dirname(filePath), { recursive: true });
+
+    // Read existing records if file exists
+    let existing = [];
+    try {
+      const content = await readFile(filePath, "utf8");
+      existing = yaml.load(content) || [];
+    } catch (err) {
+      if (err.code !== "ENOENT") throw err;
+    }
+
+    const merged = [...existing, ...records];
+    await writeFile(filePath, yaml.dump(merged, { lineWidth: -1 }));
+    console.log(`${filePath}: appended ${records.length} record(s)`);
+  }
+}


### PR DESCRIPTION
## Summary

- Replace the 4-job workflow (detect → build-matrix → analyze → update) with a single job that runs a new orchestrator script (`check-for-changes.js`) once per provider
- Extract `analyze-route-change.js` and `append-changes.js` core logic into `scripts/lib/` modules, keeping the original CLIs as thin wrappers
- Keeps the matrix at 8 entries (one per provider), avoiding the 256-job limit that was being hit with per-route matrix entries

## Test plan

- [x] Existing `append-changes` tests pass (`npm test` — 5/5)
- [ ] Push to main and verify the workflow runs successfully for all 8 providers
- [ ] Manually trigger workflow via `workflow_dispatch` to test