### PR TITLE
feat: add Z.AI, DeepSeek, and Moonshot AI monitoring

### DIFF
--- a/.github/workflows/check-for-api-changes.yml
+++ b/.github/workflows/check-for-api-changes.yml
@@ -77,6 +77,17 @@ jobs:
           - name: gladia
             openapi_url: "https://api.gladia.io/openapi.json"
             filename: openapi.json
+          - name: zai
+            openapi_url: "https://docs.z.ai/openapi.json"
+            filename: openapi.json
+          # DeepSeek does not publish the OpenAPI source used to generate its docs.
+          # Jentic maintains the only publicly available specification.
+          - name: deepseek
+            openapi_url: "https://raw.githubusercontent.com/jentic/jentic-public-apis/main/apis/openapi/deepseek.com/main/1.0.0/openapi.json"
+            filename: openapi.json
+          - name: moonshotai
+            openapi_url: "https://platform.kimi.ai/docs/openapi.json"
+            filename: openapi.json
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- add Z.AI using its official OpenAPI document
- add DeepSeek using the maintained public Jentic specification because DeepSeek does not expose its generated source
- add Moonshot AI using the official Kimi platform OpenAPI document

## Validation

- `npm test` (35 tests)
- `npx prettier --check .github/workflows/check-for-api-changes.yml`
- ran all three specifications through the CI yq and Prettier normalization pipeline