### PR TITLE
fix: make provider checks resilient to transient failures

### DIFF
--- a/.github/workflows/check-for-api-changes.yml
+++ b/.github/workflows/check-for-api-changes.yml
@@ -27,6 +27,7 @@ jobs:
       pull-requests: write
     strategy:
       fail-fast: false
+      max-parallel: 4
       matrix:
         source:
           - name: anthropic
@@ -187,7 +188,25 @@ jobs:
       - name: Merge the pull request
         if: steps.create-pr.outputs.pull-request-url != ''
         run: |
-          gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} --squash --delete-branch --repo ${{ github.repository }}
+          for attempt in 1 2 3 4 5 6; do
+            mergeable=$(gh pr view ${{ steps.create-pr.outputs.pull-request-number }} --repo ${{ github.repository }} --json mergeable --jq .mergeable)
+
+            if [ "$mergeable" = "MERGEABLE" ]; then
+              gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} --squash --delete-branch --repo ${{ github.repository }}
+              exit 0
+            fi
+
+            if [ "$mergeable" = "CONFLICTING" ]; then
+              echo "Pull request has merge conflicts"
+              exit 1
+            fi
+
+            echo "Mergeability is $mergeable; retrying in 5 seconds (attempt $attempt/6)"
+            sleep 5
+          done
+
+          echo "Timed out waiting for GitHub to determine mergeability"
+          exit 1
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/scripts/check-for-changes.js
+++ b/scripts/check-for-changes.js
@@ -232,7 +232,7 @@ function deriveRoute(relativePath) {
 
 const analysisResults = await withConcurrency(
   changedRoutes,
-  5,
+  3,
   async ({ relativePath, status, oldContent, newContent }) => {
     const route = deriveRoute(relativePath);
     console.error(`Analyzing: ${route} (${status})`);

--- a/scripts/lib/analyze-route-change.js
+++ b/scripts/lib/analyze-route-change.js
@@ -1,5 +1,6 @@
 import { generateText, Output, jsonSchema } from "ai";
 import { isIdenticalAfterNormalizingTimestamps } from "./normalize-examples.js";
+import { retryAiCall } from "./retry-ai-call.js";
 
 /**
  * Recursively strips "description", "example", and "examples" keys from an object.
@@ -256,14 +257,27 @@ export async function analyzeRouteChange({
 
   const prompt = buildPrompt(status, route, oldContent, newContent);
 
+  async function generateAnalysis(prompt) {
+    const { output } = await retryAiCall(
+      () => generateText({
+        model: "openai/gpt-5",
+        prompt,
+        output: Output.object({ schema: SCHEMA }),
+        temperature: 0.1,
+      }),
+      {
+        onRetry: ({ attempt, attempts, delayMs, error }) => {
+          console.error(`Transient AI analysis failure for ${route} on attempt ${attempt}/${attempts} (${error.message}); retrying in ${delayMs / 1_000}s`);
+        },
+      },
+    );
+
+    return output;
+  }
+
   let result;
   try {
-    ({ output: result } = await generateText({
-      model: "openai/gpt-5",
-      prompt,
-      output: Output.object({ schema: SCHEMA }),
-      temperature: 0.1,
-    }));
+    result = await generateAnalysis(prompt);
   } catch (error) {
     if (!error.message?.includes("exceeds the context window")) {
       throw error;
@@ -278,12 +292,7 @@ export async function analyzeRouteChange({
     const strippedPrompt = buildPrompt(status, route, oldSpec, newSpec);
 
     try {
-      ({ output: result } = await generateText({
-        model: "openai/gpt-5",
-        prompt: strippedPrompt,
-        output: Output.object({ schema: SCHEMA }),
-        temperature: 0.1,
-      }));
+      result = await generateAnalysis(strippedPrompt);
     } catch (strippedError) {
       if (!strippedError.message?.includes("exceeds the context window")) {
         throw strippedError;
@@ -294,12 +303,7 @@ export async function analyzeRouteChange({
 
       const diffPrompt = buildDiffPrompt(status, route, oldContent, newContent);
 
-      ({ output: result } = await generateText({
-        model: "openai/gpt-5",
-        prompt: diffPrompt,
-        output: Output.object({ schema: SCHEMA }),
-        temperature: 0.1,
-      }));
+      result = await generateAnalysis(diffPrompt);
     }
   }
 

--- a/scripts/lib/retry-ai-call.js
+++ b/scripts/lib/retry-ai-call.js
@@ -1,0 +1,109 @@
+const DEFAULT_RETRY_DELAYS_MS = [2_000, 5_000];
+
+const TRANSIENT_ERROR_CODES = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "EPIPE",
+  "ETIMEDOUT",
+  "EAI_AGAIN",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+/**
+ * Returns true when an AI SDK or Gateway error represents a transient failure.
+ * Gateway errors wrap the retryable APICallError, so inspect the complete cause
+ * chain instead of relying only on the top-level error type.
+ */
+export function isTransientAiError(error) {
+  const seen = new Set();
+
+  function visit(value) {
+    if (!value || (typeof value !== "object" && typeof value !== "function")) {
+      return false;
+    }
+    if (seen.has(value)) return false;
+    seen.add(value);
+
+    if (value.isRetryable === true) return true;
+
+    if (
+      typeof value.statusCode === "number" &&
+      (value.statusCode === 408 ||
+        value.statusCode === 429 ||
+        value.statusCode >= 500)
+    ) {
+      return true;
+    }
+
+    if (
+      typeof value.code === "string" &&
+      TRANSIENT_ERROR_CODES.has(value.code)
+    ) {
+      return true;
+    }
+
+    if (
+      typeof value.message === "string" &&
+      /\b(?:ECONNRESET|ECONNREFUSED|EPIPE|ETIMEDOUT|EAI_AGAIN|UND_ERR_[A-Z_]+)\b/.test(
+        value.message,
+      )
+    ) {
+      return true;
+    }
+
+    if (visit(value.cause)) return true;
+
+    if (value.lastError) {
+      return visit(value.lastError);
+    }
+
+    if (Array.isArray(value.errors) && value.errors.length > 0) {
+      return visit(value.errors.at(-1));
+    }
+
+    return false;
+  }
+
+  return visit(error);
+}
+
+/**
+ * Retries transient AI provider and Gateway failures that the AI SDK cannot
+ * retry itself, such as retryable APICallErrors wrapped in GatewayError.
+ */
+export async function retryAiCall(
+  fn,
+  {
+    retryDelaysMs = DEFAULT_RETRY_DELAYS_MS,
+    sleep = (delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)),
+    onRetry = ({ attempt, attempts, delayMs, error }) => {
+      console.error(
+        `Transient AI call failure on attempt ${attempt}/${attempts} (${error.message}); retrying in ${delayMs / 1_000}s`,
+      );
+    },
+  } = {},
+) {
+  const attempts = retryDelaysMs.length + 1;
+
+  for (let index = 0; index < attempts; index++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (index === attempts - 1 || !isTransientAiError(error)) {
+        throw error;
+      }
+
+      const delayMs = retryDelaysMs[index];
+      onRetry({
+        attempt: index + 1,
+        attempts,
+        delayMs,
+        error,
+      });
+      await sleep(delayMs);
+    }
+  }
+}

--- a/test/retry-ai-call.test.js
+++ b/test/retry-ai-call.test.js
@@ -1,0 +1,117 @@
+import test from "ava";
+
+import {
+  isTransientAiError,
+  retryAiCall,
+} from "../scripts/lib/retry-ai-call.js";
+
+test("isTransientAiError recognizes retryable errors wrapped by the Gateway", (t) => {
+  const error = Object.assign(new Error("Gateway request failed"), {
+    statusCode: 500,
+    cause: Object.assign(new Error("read ECONNRESET"), {
+      isRetryable: true,
+    }),
+  });
+
+  t.true(isTransientAiError(error));
+});
+
+test("isTransientAiError rejects permanent errors", (t) => {
+  const error = Object.assign(new Error("insufficient funds"), {
+    statusCode: 402,
+  });
+
+  t.false(isTransientAiError(error));
+});
+
+test("isTransientAiError uses the final error from an exhausted retry", (t) => {
+  const error = Object.assign(new Error("retry failed"), {
+    errors: [
+      Object.assign(new Error("temporary"), { statusCode: 500 }),
+      Object.assign(new Error("insufficient funds"), { statusCode: 402 }),
+    ],
+    lastError: Object.assign(new Error("insufficient funds"), {
+      statusCode: 402,
+    }),
+  });
+
+  t.false(isTransientAiError(error));
+});
+
+test("retryAiCall retries transient failures", async (t) => {
+  const delays = [];
+  const retries = [];
+  let calls = 0;
+
+  const result = await retryAiCall(
+    async () => {
+      calls++;
+      if (calls < 3) {
+        throw Object.assign(
+          new Error("Cannot connect to API: read ECONNRESET"),
+          {
+            statusCode: 500,
+          },
+        );
+      }
+      return "success";
+    },
+    {
+      retryDelaysMs: [10, 20],
+      sleep: async (delayMs) => delays.push(delayMs),
+      onRetry: ({ attempt }) => retries.push(attempt),
+    },
+  );
+
+  t.is(result, "success");
+  t.is(calls, 3);
+  t.deepEqual(delays, [10, 20]);
+  t.deepEqual(retries, [1, 2]);
+});
+
+test("retryAiCall does not retry permanent failures", async (t) => {
+  const error = Object.assign(new Error("insufficient funds"), {
+    statusCode: 402,
+  });
+  let calls = 0;
+
+  const thrown = await t.throwsAsync(
+    retryAiCall(
+      async () => {
+        calls++;
+        throw error;
+      },
+      {
+        retryDelaysMs: [0, 0],
+        sleep: async () => {},
+      },
+    ),
+  );
+
+  t.is(thrown, error);
+  t.is(calls, 1);
+});
+
+test("retryAiCall throws the final transient failure after bounded retries", async (t) => {
+  const errors = [
+    Object.assign(new Error("first"), { statusCode: 500 }),
+    Object.assign(new Error("second"), { statusCode: 500 }),
+  ];
+  let calls = 0;
+
+  const thrown = await t.throwsAsync(
+    retryAiCall(
+      async () => {
+        throw errors[calls++];
+      },
+      {
+        retryDelaysMs: [0],
+        sleep: async () => {},
+        onRetry: () => {},
+      },
+    ),
+  );
+
+  t.is(thrown, errors[1]);
+  t.is(calls, 2);
+});


### PR DESCRIPTION
The failed provider run initially hit a Vercel AI Gateway 402 because the workflow started before the Gateway credential was rotated. A fresh run then exposed two independent reliability problems: Gateway-wrapped 408/500 errors bypass the AI SDK retry logic, and newly-created PRs are sometimes queried before GitHub has computed mergeability.

This change:
- retries only transient Gateway/provider failures with bounded delays
- preserves permanent failures such as 402 without retrying
- caps workflow and per-provider AI concurrency to reduce Gateway pressure
- waits for GitHub mergeability before merging generated provider PRs
- adds focused retry classification and behavior tests

Verification:
- npx ava test/retry-ai-call.test.js (6 passing)
- node --check on all changed JavaScript files
- Prettier check for the new files and workflow
- git diff --check