### PR TITLE
fix: keep notification failures non-blocking

### DIFF
--- a/.github/workflows/check-for-api-changes.yml
+++ b/.github/workflows/check-for-api-changes.yml
@@ -212,6 +212,9 @@ jobs:
 
       - name: Send notifications
         if: steps.create-pr.outputs.pull-request-url != ''
+        # Provider monitoring succeeded once the update PR was merged. Keep a
+        # stale notification-app credential from turning that into a failed job.
+        continue-on-error: true
         env:
           APP_ID: ${{ vars.RELEASE_NOTIFIER_APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.RELEASE_NOTIFIER_PRIVATE_KEY }}


### PR DESCRIPTION
Deepgram successfully analyzed its API changes, created PR #926, and merged it. The job was nevertheless marked failed afterward because the release-notifier GitHub App credential returned a JWT decode error.

Notification delivery is downstream and best-effort, so this preserves the visible step failure while preventing it from changing a successful provider update into a failed matrix job. The RELEASE_NOTIFIER_PRIVATE_KEY still needs rotation to restore delivery.

Verification: Prettier and git diff checks pass.