### PR TITLE
fix: handle malformed Gateway generations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "ai": "^6.0.94",
+        "ai": "^6.0.264",
         "js-yaml": "^4.1.0",
         "octokit": "^5.0.3"
       },
@@ -22,14 +22,14 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.52",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.52.tgz",
-      "integrity": "sha512-lYCXP8T3YnIDiz8DP7loAMT27wnblc3IAYzQ7igg89RCRyTUjk6ffbxHXXQ5Pmv8jrdLF0ZIJnH54Dsr1OCKHg==",
+      "version": "3.0.179",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.179.tgz",
+      "integrity": "sha512-UauCMcauBgcYNljb7RP4HEuUZj3dlk/yz0oOHdhGr3cXoe+uwwN9qwQlLlB2hnajXudSatI2xpPG8LiHPRgwLQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.15",
-        "@vercel/oidc": "3.1.0"
+        "@ai-sdk/provider": "3.0.15",
+        "@ai-sdk/provider-utils": "4.0.46",
+        "@vercel/oidc": "3.2.0"
       },
       "engines": {
         "node": ">=18"
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
-      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.15.tgz",
+      "integrity": "sha512-XeZW1CcDF2GMbH4wejW6xBRI2QCOgnkVYUnxoeDadB1mf85riL2bMUeDoh+6gJ/r4mjNfzUPW8OjLjvwTP0u1Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -51,17 +51,18 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.15.tgz",
-      "integrity": "sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==",
+      "version": "4.0.46",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.46.tgz",
+      "integrity": "sha512-tEtld97plCFiYevsJuOkGkeuhQndeMWFBVrJS4AjnbD5AqrNSXRCe0p+BZ3Cju/sxDeeZ9ym3q9YUV8fASA7aQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider": "3.0.15",
         "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.6"
+        "eventsource-parser": "^3.0.8",
+        "undici": "^6.28.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.17"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -627,9 +628,9 @@
       }
     },
     "node_modules/@vercel/oidc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
-      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
@@ -692,15 +693,15 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.94",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.94.tgz",
-      "integrity": "sha512-/F9wh262HbK05b/5vILh38JvPiheonT+kBj1L97712E7VPchqmcx7aJuZN3QSk5Pj6knxUJLm2FFpYJI1pHXUA==",
+      "version": "6.0.264",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.264.tgz",
+      "integrity": "sha512-te59gArDNXoQYWuOkZNdM7n3McETAPWFuwT/iKWRJXySV/doIuKm8Az4X6IOalaGp3K8zqGT/ICn08z5ZZNDuw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.52",
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.15",
-        "@opentelemetry/api": "1.9.0"
+        "@ai-sdk/gateway": "3.0.179",
+        "@ai-sdk/provider": "3.0.15",
+        "@ai-sdk/provider-utils": "4.0.46",
+        "@opentelemetry/api": "^1.9.0"
       },
       "engines": {
         "node": ">=18"
@@ -1334,9 +1335,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -2601,6 +2602,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
@@ -2922,9 +2932,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "ava"
   },
   "dependencies": {
-    "ai": "^6.0.94",
+    "ai": "^6.0.264",
     "js-yaml": "^4.1.0",
     "octokit": "^5.0.3"
   },

--- a/scripts/lib/retry-ai-call.js
+++ b/scripts/lib/retry-ai-call.js
@@ -54,6 +54,17 @@ export function isTransientAiError(error) {
       return true;
     }
 
+    // A malformed Gateway generation can omit finishReason and make AI SDK v6
+    // throw before it can surface a typed provider error.
+    if (
+      typeof value.message === "string" &&
+      /Cannot read properties of undefined \(reading ['"]unified['"]\)/.test(
+        value.message,
+      )
+    ) {
+      return true;
+    }
+
     if (visit(value.cause)) return true;
 
     if (value.lastError) {

--- a/test/retry-ai-call.test.js
+++ b/test/retry-ai-call.test.js
@@ -24,6 +24,14 @@ test("isTransientAiError rejects permanent errors", (t) => {
   t.false(isTransientAiError(error));
 });
 
+test("isTransientAiError recognizes malformed AI SDK generation results", (t) => {
+  const error = new TypeError(
+    "Cannot read properties of undefined (reading 'unified')",
+  );
+
+  t.true(isTransientAiError(error));
+});
+
 test("isTransientAiError uses the final error from an exhausted retry", (t) => {
   const error = Object.assign(new Error("retry failed"), {
     errors: [


### PR DESCRIPTION
The repaired Anthropic job successfully retried an ECONNRESET, then later crashed inside AI SDK 6.0.94 because a malformed Gateway result omitted finishReason. The SDK tried to read result.finishReason.unified before it could surface a typed error.

This updates within the existing AI SDK 6.x range to 6.0.264 (Gateway 3.0.179 instead of 3.0.52) and treats only that exact malformed-result TypeError as transient, using the existing bounded retry budget.

Verification:
- clean npm ci from the updated lockfile
- 32 safe tests pass, including the new classifier test
- module import and syntax checks pass
- Prettier and git diff checks pass

The generated README test remains independently stale after merged provider route updates; that is addressed by the separate readme-route-lists work.