### PR TITLE
fix: allow large provider checks to finish

### DIFF
--- a/.github/workflows/check-for-api-changes.yml
+++ b/.github/workflows/check-for-api-changes.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
The concurrency reduction keeps concurrent Gateway calls bounded, but TogetherAI and OpenAI currently have 182 and 175 changed routes. Both were still legitimately processing after 20 minutes, making the previous 30-minute job timeout too tight once route concurrency is capped at three.

Extend matrix job timeouts to 60 minutes so large update batches can finish without restoring the Gateway pressure that caused the original failures.

Verification: Prettier and git diff checks pass.