### PR TITLE
fix: leave headroom for large provider checks

### DIFF
--- a/.github/workflows/check-for-api-changes.yml
+++ b/.github/workflows/check-for-api-changes.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

- increase the provider job timeout from 60 to 90 minutes
- leave a safe margin for large OpenAI spec updates

## Evidence

The final-code verification run reached roughly 57 minutes for OpenAI while still analyzing. TogetherAI required 35m20s and Anthropic required 42m04s, so a 60-minute ceiling remains too close to observed production runtime.

## Verification

- Prettier check passed for the workflow
- git diff check passed