### PR TITLE
fix: retry malformed AI usage responses

### DIFF
--- a/scripts/lib/retry-ai-call.js
+++ b/scripts/lib/retry-ai-call.js
@@ -54,11 +54,11 @@ export function isTransientAiError(error) {
       return true;
     }
 
-    // A malformed Gateway generation can omit finishReason and make AI SDK v6
-    // throw before it can surface a typed provider error.
+    // A malformed Gateway generation can omit finishReason or usage and make
+    // AI SDK v6 throw before it can surface a typed provider error.
     if (
       typeof value.message === "string" &&
-      /Cannot read properties of undefined \(reading ['"]unified['"]\)/.test(
+      /Cannot read properties of undefined \(reading ['"](?:unified|inputTokens)['"]\)/.test(
         value.message,
       )
     ) {

--- a/test/retry-ai-call.test.js
+++ b/test/retry-ai-call.test.js
@@ -25,11 +25,15 @@ test("isTransientAiError rejects permanent errors", (t) => {
 });
 
 test("isTransientAiError recognizes malformed AI SDK generation results", (t) => {
-  const error = new TypeError(
+  const missingFinishReason = new TypeError(
     "Cannot read properties of undefined (reading 'unified')",
   );
+  const missingUsage = new TypeError(
+    "Cannot read properties of undefined (reading 'inputTokens')",
+  );
 
-  t.true(isTransientAiError(error));
+  t.true(isTransientAiError(missingFinishReason));
+  t.true(isTransientAiError(missingUsage));
 });
 
 test("isTransientAiError uses the final error from an exhausted retry", (t) => {


### PR DESCRIPTION
## Summary

- recognize the AI SDK missing usage.inputTokens failure as a malformed Gateway result
- retry it with the same bounded budget as the existing missing finishReason signature
- retain normal failures for unrelated TypeErrors

## Evidence

OpenAI job 97530199657 received a Gateway generation without usage metadata. AI SDK 6.0.264 threw while normalizing the result before it could produce a typed provider error.

## Verification

- seven focused retry tests pass
- Prettier check passes
- git diff check passes