### PR TITLE
ci: run provider checks for runtime changes

### DIFF
--- a/.github/workflows/check-for-api-changes.yml
+++ b/.github/workflows/check-for-api-changes.yml
@@ -12,7 +12,9 @@ on:
     paths:
       - ".github/workflows/check-for-api-changes.yml"
       - "scripts/check-for-changes.js"
-      - "scripts/lib/download.js"
+      - "scripts/lib/**"
+      - "package.json"
+      - "package-lock.json"
 
 concurrency:
   group: check-for-api-changes


### PR DESCRIPTION
Expand the push path filter to cover every runtime helper and the package manifests. This makes retry/helper and dependency changes validate the provider matrix automatically instead of requiring a manual workflow dispatch.

Validation:
- npx prettier --check .github/workflows/check-for-api-changes.yml
- git diff --check