### PR TITLE
fix: cap generated provider PR bodies

### DIFF
--- a/scripts/check-for-changes.js
+++ b/scripts/check-for-changes.js
@@ -31,6 +31,7 @@ import yaml from "js-yaml";
 
 import { analyzeRouteChange } from "./lib/analyze-route-change.js";
 import { appendChanges } from "./lib/append-changes.js";
+import { buildPullRequestBody } from "./lib/build-pull-request-body.js";
 import { downloadText, resolveUrlFromMetadata } from "./lib/download.js";
 import { isIdenticalAfterNormalizingTimestamps } from "./lib/normalize-examples.js";
 
@@ -278,35 +279,7 @@ if (allChanges.length === 1) {
   title = `update ${provider} API specification (${allChanges.length} changes)`;
 }
 
-let body = "";
-const breaking = allChanges.filter((c) => c.breaking);
-const features = allChanges.filter(
-  (c) => !c.breaking && c.change !== "removed" && !c.doc_only,
-);
-const docFixes = allChanges.filter((c) => c.doc_only);
-
-if (breaking.length > 0) {
-  body += "### Breaking changes\n\n";
-  for (const c of breaking) {
-    body += `- **${c.route}**: ${c.note}\n`;
-  }
-  body += "\n";
-}
-
-if (features.length > 0) {
-  body += "### New features\n\n";
-  for (const c of features) {
-    body += `- **${c.route}**: ${c.note}\n`;
-  }
-  body += "\n";
-}
-
-if (docFixes.length > 0) {
-  body += "### Documentation fixes\n\n";
-  for (const c of docFixes) {
-    body += `- **${c.route}**: ${c.note}\n`;
-  }
-}
+const body = buildPullRequestBody(provider, allChanges);
 
 // --- Step 11: Build changed_routes for notifications ---
 const changed_routes = changedRoutes.map(({ relativePath, status }, index) => {

--- a/scripts/lib/build-pull-request-body.js
+++ b/scripts/lib/build-pull-request-body.js
@@ -1,0 +1,54 @@
+export const MAX_PULL_REQUEST_BODY_BYTES = 60_000;
+
+/**
+ * Builds a provider update PR description while keeping the action input below
+ * GitHub's body limit and Linux's per-argument limit. The committed change
+ * files remain the complete source of truth when the summary is truncated.
+ */
+export function buildPullRequestBody(
+  provider,
+  allChanges,
+  { maxBytes = MAX_PULL_REQUEST_BODY_BYTES } = {},
+) {
+  let body = "";
+  const breaking = allChanges.filter((change) => change.breaking);
+  const features = allChanges.filter(
+    (change) =>
+      !change.breaking && change.change !== "removed" && !change.doc_only,
+  );
+  const docFixes = allChanges.filter((change) => change.doc_only);
+
+  for (const [heading, changes, trailingBlankLine] of [
+    ["Breaking changes", breaking, true],
+    ["New features", features, true],
+    ["Documentation fixes", docFixes, false],
+  ]) {
+    if (changes.length === 0) continue;
+
+    body += `### ${heading}\n\n`;
+    for (const change of changes) {
+      body += `- **${change.route}**: ${change.note}\n`;
+    }
+    if (trailingBlankLine) body += "\n";
+  }
+
+  if (Buffer.byteLength(body, "utf8") <= maxBytes) return body;
+
+  const footer = `\n\n---\n\n_PR description truncated. Complete change records are committed under \`changes/${provider}/\`._`;
+  const footerBytes = Buffer.byteLength(footer, "utf8");
+  if (footerBytes > maxBytes) {
+    throw new RangeError("maxBytes is too small for the truncation notice");
+  }
+
+  const prefixBudget = maxBytes - footerBytes;
+  let prefix = "";
+  let prefixBytes = 0;
+  for (const line of body.match(/[^\n]*\n|[^\n]+$/g) ?? []) {
+    const lineBytes = Buffer.byteLength(line, "utf8");
+    if (prefixBytes + lineBytes > prefixBudget) break;
+    prefix += line;
+    prefixBytes += lineBytes;
+  }
+
+  return prefix.trimEnd() + footer;
+}

--- a/test/build-pull-request-body.test.js
+++ b/test/build-pull-request-body.test.js
@@ -1,0 +1,64 @@
+import test from "ava";
+
+import { buildPullRequestBody } from "../scripts/lib/build-pull-request-body.js";
+
+test("buildPullRequestBody groups provider changes", (t) => {
+  const body = buildPullRequestBody("example", [
+    {
+      route: "POST /breaking",
+      note: "Removed a required field",
+      breaking: true,
+      change: "removed",
+      doc_only: false,
+    },
+    {
+      route: "GET /feature",
+      note: "Added a response field",
+      breaking: false,
+      change: "added",
+      doc_only: false,
+    },
+    {
+      route: "GET /docs",
+      note: "Clarified a description",
+      breaking: false,
+      change: "changed",
+      doc_only: true,
+    },
+  ]);
+
+  t.is(
+    body,
+    `### Breaking changes
+
+- **POST /breaking**: Removed a required field
+
+### New features
+
+- **GET /feature**: Added a response field
+
+### Documentation fixes
+
+- **GET /docs**: Clarified a description
+`,
+  );
+});
+
+test("buildPullRequestBody truncates oversized summaries on a line boundary", (t) => {
+  const changes = Array.from({ length: 20 }, (_, index) => ({
+    route: `GET /route-${index}`,
+    note: "🚀 A detailed provider change that would make the action input too large",
+    breaking: false,
+    change: "added",
+    doc_only: false,
+  }));
+
+  const body = buildPullRequestBody("large-provider", changes, {
+    maxBytes: 240,
+  });
+
+  t.true(Buffer.byteLength(body, "utf8") <= 240);
+  t.regex(body, /PR description truncated/);
+  t.true(body.endsWith("`changes/large-provider/`._"));
+  t.false(body.includes("GET /route-19"));
+});


### PR DESCRIPTION
The OpenAI check successfully analyzed all 257 routes in run 32764398159, but peter-evans/create-pull-request could not start because the generated PR body exceeded Linux's per-argument limit.

Move PR-body construction into a tested helper and cap oversized descriptions at 60,000 UTF-8 bytes on a complete line boundary. The full generated cache and change files remain untouched; a truncation notice points readers to the committed change records. Normal-sized PR descriptions keep their existing content and formatting.

Validation:
- npx prettier --check scripts/lib/build-pull-request-body.js test/build-pull-request-body.test.js scripts/check-for-changes.js
- node --check scripts/lib/build-pull-request-body.js
- node --check scripts/check-for-changes.js
- npx ava test/build-pull-request-body.test.js test/normalize-examples.test.js test/download.test.js test/derive-operation-id.test.js test/retry-ai-call.test.js (34 passed)
- git diff --check