### PR TITLE
fix: pass notification payload via environment

### DIFF
--- a/.github/workflows/check-for-api-changes.yml
+++ b/.github/workflows/check-for-api-changes.yml
@@ -227,8 +227,10 @@ jobs:
         env:
           APP_ID: ${{ vars.RELEASE_NOTIFIER_APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.RELEASE_NOTIFIER_PRIVATE_KEY }}
+          SOURCE_NAME: ${{ matrix.source.name }}
+          CHANGED_ROUTES: ${{ steps.check.outputs.changed_routes }}
         run: |
-          node scripts/send-notifications.js "${{ matrix.source.name }}" '${{ steps.check.outputs.changed_routes }}'
+          node scripts/send-notifications.js "$SOURCE_NAME" "$CHANGED_ROUTES"
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary

- pass the provider name and changed routes through the notification step environment
- expand those variables only when invoking the notification script
- prevent quotes inside JSON change descriptions from being interpreted as shell syntax

## Verification

- npx --no-install prettier --check .github/workflows/check-for-api-changes.yml
- parsed the workflow with js-yaml and verified the notification step environment and command
- exercised the command shape with a JSON note containing an apostrophe
- npm test: all tests except the existing README route-generation check pass; README.md is already out of date on main